### PR TITLE
When user login fail, clean cookie

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -266,6 +266,7 @@ void OwncloudSetupWizard::slotAuthError()
         _ocWizard->back();
     }
     _ocWizard->displayError(errorMsg, _ocWizard->currentId() == WizardCommon::Page_ServerSetup && checkDowngradeAdvised(reply));
+    _ocWizard->account()->clearCookieJar();
 }
 
 bool OwncloudSetupWizard::checkDowngradeAdvised(QNetworkReply* reply)


### PR DESCRIPTION
In order to implement disable user in owncloud server,
os client needs to clean cookie when user is disable login,
or will occur loging error.
